### PR TITLE
appender: fix a bug that writeAppend will truncate data if file exists

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -318,7 +318,7 @@ func (s *Storage) write(ctx context.Context, path string, r io.Reader, size int6
 }
 
 func (s *Storage) writeAppend(ctx context.Context, o *Object, r io.Reader, size int64, opt pairStorageWriteAppend) (n int64, err error) {
-	f, needClose, err := s.createFile(o.ID)
+	f, needClose, err := s.createFileWithFlag(o.ID, os.O_RDWR|os.O_CREATE|os.O_APPEND)
 	if err != nil {
 		return
 	}

--- a/utils.go
+++ b/utils.go
@@ -118,6 +118,10 @@ func (s *Storage) openFile(absPath string, mode int) (f *os.File, needClose bool
 }
 
 func (s *Storage) createFile(absPath string) (f *os.File, needClose bool, err error) {
+	return s.createFileWithFlag(absPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC)
+}
+
+func (s *Storage) createFileWithFlag(absPath string, flag int) (f *os.File, needClose bool, err error) {
 	switch absPath {
 	case Stdin:
 		return os.Stdin, false, nil
@@ -152,8 +156,7 @@ func (s *Storage) createFile(absPath string) (f *os.File, needClose bool, err er
 	// There are two situations we handled here:
 	// - The file is exist and not a dir
 	// - The file is not exist
-	// It's OK to open them with O_CREATE|O_TRUNC.
-	f, err = os.Create(absPath)
+	f, err = os.OpenFile(absPath, flag, 0666)
 	if err != nil {
 		return nil, false, err
 	}


### PR DESCRIPTION
`writeAppend` will call `createFileWithFlag` with no `truncate` flag, and the others are not changed.