### PR TITLE
fix: Fixed workDir not matching when workDir is a symbolic link

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -71,7 +71,11 @@ func newStorager(pairs ...typ.Pair) (store *Storage, err error) {
 		store.features = opt.StorageFeatures
 	}
 	if opt.HasWorkDir {
-		store.workDir = opt.WorkDir
+		workDir, err := filepath.EvalSymlinks(opt.WorkDir)
+		if err != nil {
+			return nil, err
+		}
+		store.workDir = workDir
 	}
 
 	// Check and create work dir


### PR DESCRIPTION
fix: Fixed workDir not matching when workDir is a symbolic link